### PR TITLE
Add interactions endpoint and deployment with Front-end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,23 +2,17 @@ version: '3.8'
 
 services:
   flask_app:
-    container_name: flask_api
+    container_name: flask_app
     restart: always
     build: ./flask_app
-    volumes: ['./flask_app:/flask_app']  # left is api folder, right is wkdir defined in flask_app/Dockerfile
-    networks:
-      - linkage
-    ports:
-      - "5000:5000"
+    volumes: [ './flask_app:/flask_app' ]   
+  front_end:
+    container_name: front_end
+    restart: always
+    image: public.ecr.aws/dissco/bicikl-linkages-front-end:latest
   nginx:
     container_name: nginx
     restart: always
     build: ./nginx
-    networks:
-      - linkage
-    expose:
-      - "8080"
     ports:
-      - "80:8080"
-networks:
-  linkage:
+      - "80:80"

--- a/flask_app/Dockerfile
+++ b/flask_app/Dockerfile
@@ -7,12 +7,12 @@ RUN apt-get update && apt-get install -y libpq-dev && apt-get install python3-de
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-COPY ./api app/api
-COPY ./bin app/bin
-COPY ./classifiers app/classifiers
-COPY wsgi.py app/wsgi.py
-
 WORKDIR /app
+
+COPY ./api ./api
+COPY ./bin ./bin
+COPY ./classifiers ./classifiers
+COPY wsgi.py ./
 
 EXPOSE 5000
 ENTRYPOINT ["bash", "/app/bin/bootstrap.sh"]

--- a/flask_app/api/app.py
+++ b/flask_app/api/app.py
@@ -56,7 +56,6 @@ def pollinator_of(taxon_id):
 
 
 @app.route("/pollinatedBy/<taxon_id>")
-@app.route("/pollinatorOf/<taxon_id>/<conf>")
 def pollinated_by(taxon_id, conf=0.95):
     # Given a pollinator, return plants pollinated by the pollinator
     relation = "pollinates"
@@ -132,7 +131,7 @@ def hosts(taxon_id):
 
     # 1007770 (membranacea) parasiteOf 5422328 (pyrifera)
 
-@app.route("/predict")
+@app.route("/predict", methods=["GET", "POST"])
 def predict():
     request_data = request.get_json()
 
@@ -148,6 +147,25 @@ def predict():
     predicted_dict = {"Predicted": predictions.controller(relation, taxon_id, is_subject, confidence, strict, check)}
 
     return {**queried_dict, **predicted_dict}
+
+@app.route("/interactions", methods=["GET"])
+def interactions():
+    interactions_list = {
+        "pollinates": [
+            ['pollinaterOf', 'Pollinater of'],
+            ['pollinatedBy', 'Pollinated by']
+        ],
+        "preysOn": [
+            ['predatorOf', 'Predator of'],
+            ['predatedBy', 'Predated by']
+        ],
+        "parasiteOf": [
+            ['parasitizes', 'Parasitizes'],
+            ['parasitizedBy', 'Parasitized by']
+        ]
+    }
+
+    return {"Interactions": interactions_list}
 
 def check_args(conf):
     if type(conf) != float or conf > 1 or conf < 0:

--- a/flask_app/bin/bootstrap.sh
+++ b/flask_app/bin/bootstrap.sh
@@ -2,5 +2,5 @@
 
 #export FLASK_APP=./app.py
 #source $(pip --venv)/bin/activate
-cd ../
+# cd ../
 gunicorn wsgi:app --bind 0.0.0.0:5000 --workers=4

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,22 +1,33 @@
-worker_processes  3;
+worker_processes 3;
 
-events { }
+events {
+}
 
 http {
 
-  keepalive_timeout  360s;
+  keepalive_timeout 360s;
 
   server {
+    include mime.types;
 
-      listen 8080;
-      server_name flask_app;
-      charset utf-8;
+    listen 80;
+    # charset utf-8;
 
-      location / {
-          proxy_pass http://flask_app:5000;
-          proxy_set_header Host $host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      }
+    location / {
+      proxy_pass http://front_end:3000;
+      root /usr/share/nginx/html;
+      index index.html index.htm;
+      try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+      proxy_pass http://flask_app:5000/;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+
+    location = /50x.html {
+      root /usr/share/nginx/html;
+    }
   }
 }


### PR DESCRIPTION
Commit adds an interactions endpoint to the API that returns a list of all possible interaction methods per relation type. NGINX and Docker Compose files have been adjusted to incorporate the Front-end as well.

Adds:
- /interactions endpoint for listing all interaction types per relation type
- NGINX and Docker Compose configuration for incorporating the front-end.
- POST method to /predict endpoint

Removes:
- Duplicate endpoint route we detected for pollinatedBy / pollinatorOf