### PR TITLE
Fix NGINX configuration

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,20 +4,13 @@ events {
 }
 
 http {
-
   keepalive_timeout 360s;
 
   server {
-    include mime.types;
-
     listen 80;
-    # charset utf-8;
 
     location / {
       proxy_pass http://front_end:3000;
-      root /usr/share/nginx/html;
-      index index.html index.htm;
-      try_files $uri $uri/ /index.html;
     }
 
     location /api {


### PR DESCRIPTION
Commit hopefully fixes NGINX configuration. Error was probably because of the root for React was set to an unknown folder, why it could not find and set the right MIME-types, removed this set-up and it runs locally, now to test for production.